### PR TITLE
remove useless objects passed to callback

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -188,7 +188,24 @@ Client.prototype._defineMethod = function(method, location) {
       options = temp;
     }
     self._invoke(method, args, location, function(error, result, rawResponse, soapHeader, rawRequest) {
-      callback(error, result, rawResponse, soapHeader, rawRequest);
+      /**
+       * because all invoked "callback" just use "error" and "result", 
+       * don't pass useless object to "callback" may save memory,
+       * and all used properties in "error.response" objects are "statusCode, headers, statusMessage"
+       */
+      rawResponse = null
+      soapHeader = null
+      rawRequest = null
+      if(error && error.response) {
+        var error_res = { 
+          headers: error.response.headers,
+          statusCode: error.response.statusCode,
+          statusMessage: error.response.statusMessage 
+        };
+        error.response = null
+        error.response = error_res
+      }
+      callback(error, result);
     }, options, extraHTTPHeaders, extraSOAPHeaders);
   };
 };

--- a/lib/http.js
+++ b/lib/http.js
@@ -10,7 +10,7 @@ var req = require('request');
 var debug = require('debug')('node-soap');
 
 var VERSION = require('../package.json').version;
-var DEFAULT_TIMEOUT = 20000 //each request abort when it takes more than 20s by default
+//var DEFAULT_TIMEOUT = 20000 //each request abort when it takes more than 20s by default
 
 /**
  * A class representing the http client
@@ -65,9 +65,11 @@ HttpClient.prototype.buildRequest = function(rurl, data, exheaders, exoptions) {
     uri: curl,
     method: method,
     headers: headers,
-    followAllRedirects: true,
-    timeout: (exoptions && exoptions.timeout) || DEFAULT_TIMEOUT
+    followAllRedirects: true
   };
+  if(exoptions && exoptions.timeout !== undefined) { 
+    options.timeout = exoptions.timeout
+  }
 
 
   options.body = data;

--- a/lib/http.js
+++ b/lib/http.js
@@ -10,6 +10,7 @@ var req = require('request');
 var debug = require('debug')('node-soap');
 
 var VERSION = require('../package.json').version;
+var TIMEOUT = 10000 //each request abort when it takes more than 10s
 
 /**
  * A class representing the http client
@@ -64,7 +65,8 @@ HttpClient.prototype.buildRequest = function(rurl, data, exheaders, exoptions) {
     uri: curl,
     method: method,
     headers: headers,
-    followAllRedirects: true
+    followAllRedirects: true,
+    timeout: TIMEOUT
   };
 
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -10,7 +10,7 @@ var req = require('request');
 var debug = require('debug')('node-soap');
 
 var VERSION = require('../package.json').version;
-var TIMEOUT = 10000 //each request abort when it takes more than 10s
+var DEFAULT_TIMEOUT = 20000 //each request abort when it takes more than 20s by default
 
 /**
  * A class representing the http client
@@ -66,7 +66,7 @@ HttpClient.prototype.buildRequest = function(rurl, data, exheaders, exoptions) {
     method: method,
     headers: headers,
     followAllRedirects: true,
-    timeout: TIMEOUT
+    timeout: (exoptions && exoptions.timeout) || DEFAULT_TIMEOUT
   };
 
 


### PR DESCRIPTION
GC will release memory of soap request after "self._invoke()", might a feasible solution for the memory issue